### PR TITLE
Feat/improve dataloading

### DIFF
--- a/src/client/components/oil-rigs/oil-rigs.jsx
+++ b/src/client/components/oil-rigs/oil-rigs.jsx
@@ -14,23 +14,27 @@ import styles from "./oil-rigs.module.less";
 import { useSortByString } from "src/client/hooks/use-sort-by-string";
 import { SortOrderSelect } from "../shared/sort-order-select";
 import LoadingOverlay from "../shared/loading-overlay";
+import { sitesLoaded } from "src/client/store/entities/sites/sites";
 
-const OilRigs = ({ list, loading, oilRigsLoaded }) => {
+const OilRigs = ({ listOilRigs, loading, oilRigsLoaded, listSites }) => {
   const { order, sortedList, handleSortChange } = useSortByString(
-    list,
+    listOilRigs,
     (site) => site.name
   );
+  console.log(listOilRigs);
+  console.log(listSites);
+
   return (
     <Card heading={<Heading>List of oil rigs</Heading>}>
       <Row>
         <Column width={200}>
-          <Button
+          {/* <Button
             label="Load oil rigs"
             onClick={oilRigsLoaded}
             loading={loading}
             disabled={loading}
           />
-          <Spacer />
+          <Spacer /> */}
           <SortOrderSelect onChange={handleSortChange} />
         </Column>
         <Column>
@@ -64,15 +68,16 @@ const OilRigs = ({ list, loading, oilRigsLoaded }) => {
 };
 
 const mapStateToProps = ({ entities }) => {
-  const { oilRigs } = entities;
+  const { oilRigs, sites } = entities;
   return {
     loading: oilRigs.loading,
-    list: oilRigs.list,
+    listOilRigs: oilRigs.list,
+    listSites: sites.list,
   };
 };
 
 const mapDispatchToProps = {
-  oilRigsLoaded,
+  oilRigsLoaded, sitesLoaded
 };
 
 const ConnectedOilRigs = connect(mapStateToProps, mapDispatchToProps)(OilRigs);

--- a/src/client/components/oil-rigs/oil-rigs.jsx
+++ b/src/client/components/oil-rigs/oil-rigs.jsx
@@ -21,8 +21,6 @@ const OilRigs = ({ listOilRigs, loading, oilRigsLoaded, listSites }) => {
     listOilRigs,
     (site) => site.name
   );
-  console.log(listOilRigs);
-  console.log(listSites);
 
   return (
     <Card heading={<Heading>List of oil rigs</Heading>}>

--- a/src/client/components/site-chart/sites-chart.jsx
+++ b/src/client/components/site-chart/sites-chart.jsx
@@ -22,9 +22,11 @@ import {
 } from "recharts";
 import { sitesLoaded } from "src/client/store/entities/sites/sites";
 import LoadingOverlay from "../shared/loading-overlay";
+import { oilRigsLoaded } from "src/client/store/entities/oil-rigs/oil-rigs";
 
-const SitesChart = ({ list, loading, sitesLoaded }) => {
-  // add validation check: only display number of oil rigs that are true (Statfjord should have 4, not 5 rigs)
+const SitesChart = ({ listSites, loadingSites, sitesLoaded, listOilRigs }) => {
+  // add validation check: only display number of oil rigs that are a match with listOilRigs (Statfjord should have 4, not 5 rigs)
+  // filter out id's that match id's from the listOilRigs.
 
   return (
     <>
@@ -40,13 +42,13 @@ const SitesChart = ({ list, loading, sitesLoaded }) => {
           {/* </Column> */}
           <Column>
             <div style={{ width: "100%", height: 360 }}>
-              {loading && !list && <LoadingOverlay />}
-              {!loading && list.length > 0 ? (
+              {loadingSites && !listSites && <LoadingOverlay />}
+              {!loadingSites && listSites.length > 0 ? (
                 <ResponsiveContainer width="100%" height="100%">
                   <BarChart
                     width={500}
                     height={300}
-                    data={list}
+                    data={listSites}
                     margin={{
                       top: 5,
                       right: 30,
@@ -90,16 +92,19 @@ const SitesChart = ({ list, loading, sitesLoaded }) => {
 };
 
 const mapStateToProps = ({ entities }) => {
-  const { sites } = entities;
+  const { sites, oilRigs } = entities;
 
   return {
-    loading: sites.loading,
-    list: sites.list,
+    loadingSites: sites.loading,
+    listSites: sites.list,
+    loadingOilRigs: oilRigs.loading,
+    listOilRigs: oilRigs.list,
   };
 };
 
 const mapDispatchToProps = {
   sitesLoaded,
+  oilRigsLoaded,
 };
 
 const ConnectedSites = connect(mapStateToProps, mapDispatchToProps)(SitesChart);

--- a/src/client/components/site-chart/sites-chart.jsx
+++ b/src/client/components/site-chart/sites-chart.jsx
@@ -24,15 +24,14 @@ import { sitesLoaded } from "src/client/store/entities/sites/sites";
 import LoadingOverlay from "../shared/loading-overlay";
 
 const SitesChart = ({ list, loading, sitesLoaded }) => {
-
   // add validation check: only display number of oil rigs that are true (Statfjord should have 4, not 5 rigs)
-  
+
   return (
     <>
       <Card heading={<Heading>Chart of oil rigs on sites</Heading>}>
         <Row>
           {/* <Column width={200}> */}
-            {/* <Button
+          {/* <Button
               label="Load sites"
               onClick={sitesLoaded}
               loading={loading}

--- a/src/client/components/site-chart/sites-chart.jsx
+++ b/src/client/components/site-chart/sites-chart.jsx
@@ -24,18 +24,21 @@ import { sitesLoaded } from "src/client/store/entities/sites/sites";
 import LoadingOverlay from "../shared/loading-overlay";
 
 const SitesChart = ({ list, loading, sitesLoaded }) => {
+
+  // add validation check: only display number of oil rigs that are true (Statfjord should have 4, not 5 rigs)
+  
   return (
     <>
       <Card heading={<Heading>Chart of oil rigs on sites</Heading>}>
         <Row>
-          <Column width={200}>
-            <Button
+          {/* <Column width={200}> */}
+            {/* <Button
               label="Load sites"
               onClick={sitesLoaded}
               loading={loading}
               disabled={loading}
-            />
-          </Column>
+            /> */}
+          {/* </Column> */}
           <Column>
             <div style={{ width: "100%", height: 360 }}>
               {loading && !list && <LoadingOverlay />}

--- a/src/client/components/sites/sites.jsx
+++ b/src/client/components/sites/sites.jsx
@@ -16,30 +16,54 @@ import styles from "./sites.module.less";
 import { useSortByString } from "src/client/hooks/use-sort-by-string";
 import { SortOrderSelect } from "../shared/sort-order-select";
 import LoadingOverlay from "../shared/loading-overlay";
+import { oilRigsLoaded } from "src/client/store/entities/oil-rigs/oil-rigs";
 
-const Sites = ({ list, loading, sitesLoaded }) => {
+const Sites = ({ listSites, loadingSites, sitesLoaded, listOilRigs }) => {
   const { search } = useLocation();
   const { sortedList, handleSortChange } = useSortByString(
-    list,
+    listSites,
     (site) => site.name
   );
+
+  // get oil rigs for each site ✅
+  // match oil rigs id's with the oil rigs for each site ✅
+  // display the name of the oil rigs on each site
+
+  console.log(listSites);
+  console.log(listOilRigs);
+
+  const rigsId = listOilRigs.map((rig) => rig.id);
+  const rigName = listOilRigs.map((rig) => rig.name);
+  console.log(rigName);
+
+  const rigsAtSite = listSites.map((site) => site.oilRigs);
+  console.log("rigs at site", rigsAtSite);
+  rigsAtSite.forEach((rig) => {
+    const match = rig.filter((id) => rigsId.includes(id));
+
+    if (match) {
+      console.log("MATCH:", "rig:", rig, "match:", match, "name:");
+    } else {
+      console.log("no match", "rig", rig);
+    }
+  });
 
   return (
     <Card heading={<Heading>List of oil sites</Heading>}>
       <Row>
         <Column width={200}>
-          <Button
+          {/* <Button
             label="Load sites"
             onClick={sitesLoaded}
-            loading={loading}
-            disabled={loading}
+            loading={loadingSites}
+            disabled={loadingSites}
           />
-          <Spacer />
+          <Spacer /> */}
           <SortOrderSelect onChange={handleSortChange} />
         </Column>
         <Column>
           <div className={styles.sitesList}>
-            {loading && !sortedList && <LoadingOverlay />}
+            {loadingSites && !sortedList && <LoadingOverlay />}
             {!sortedList && !loading && (
               <em>Could not load sites. Please try again.</em>
             )}
@@ -63,9 +87,11 @@ const Sites = ({ list, loading, sitesLoaded }) => {
                         managed
                       >
                         <ul>
-                          {site.oilRigs.map((oilRig) => (
-                            <li key={oilRig}>{oilRig}</li>
-                          ))}
+                          {site.oilRigs.map((oilRig) => {
+                            // console.log('oil rigs on site', oilRig);
+
+                            return <li key={oilRig}>{oilRig}</li>;
+                          })}
                         </ul>
                       </Accordion>
                     </Card>
@@ -83,16 +109,19 @@ const Sites = ({ list, loading, sitesLoaded }) => {
 };
 
 const mapStateToProps = ({ entities }) => {
-  const { sites } = entities;
+  const { sites, oilRigs } = entities;
 
   return {
-    loading: sites.loading,
-    list: sites.list,
+    loadingSites: sites.loading,
+    listSites: sites.list,
+    loadingOilRigs: oilRigs.loading,
+    listOilRigs: oilRigs.list,
   };
 };
 
 const mapDispatchToProps = {
   sitesLoaded,
+  oilRigsLoaded,
 };
 
 const ConnectedSites = connect(mapStateToProps, mapDispatchToProps)(Sites);

--- a/src/client/components/sites/sites.jsx
+++ b/src/client/components/sites/sites.jsx
@@ -18,7 +18,7 @@ import { SortOrderSelect } from "../shared/sort-order-select";
 import LoadingOverlay from "../shared/loading-overlay";
 import { oilRigsLoaded } from "src/client/store/entities/oil-rigs/oil-rigs";
 
-const Sites = ({ listSites, loadingSites, sitesLoaded, listOilRigs }) => {
+const Sites = ({ listSites, loadingSites, listOilRigs, loadingOilRigs }) => {
   const { search } = useLocation();
   const { sortedList, handleSortChange } = useSortByString(
     listSites,

--- a/src/client/components/sites/sites.jsx
+++ b/src/client/components/sites/sites.jsx
@@ -25,29 +25,6 @@ const Sites = ({ listSites, loadingSites, sitesLoaded, listOilRigs }) => {
     (site) => site.name
   );
 
-  // get oil rigs for each site ✅
-  // match oil rigs id's with the oil rigs for each site ✅
-  // display the name of the oil rigs on each site
-
-  console.log(listSites);
-  console.log(listOilRigs);
-
-  const rigsId = listOilRigs.map((rig) => rig.id);
-  const rigName = listOilRigs.map((rig) => rig.name);
-  console.log(rigName);
-
-  const rigsAtSite = listSites.map((site) => site.oilRigs);
-  console.log("rigs at site", rigsAtSite);
-  rigsAtSite.forEach((rig) => {
-    const match = rig.filter((id) => rigsId.includes(id));
-
-    if (match) {
-      console.log("MATCH:", "rig:", rig, "match:", match, "name:");
-    } else {
-      console.log("no match", "rig", rig);
-    }
-  });
-
   return (
     <Card heading={<Heading>List of oil sites</Heading>}>
       <Row>
@@ -87,10 +64,12 @@ const Sites = ({ listSites, loadingSites, sitesLoaded, listOilRigs }) => {
                         managed
                       >
                         <ul>
-                          {site.oilRigs.map((oilRig) => {
-                            // console.log('oil rigs on site', oilRig);
-
-                            return <li key={oilRig}>{oilRig}</li>;
+                          {site.oilRigs.map((rigId) => {
+                            const rig = listOilRigs.find(
+                              (rig) => rig.id === rigId
+                            );
+                            if (!rig) return;
+                            return <li key={rig.id}>{rig.name}</li>;
                           })}
                         </ul>
                       </Accordion>

--- a/src/client/hooks/use-sort-by-string.js
+++ b/src/client/hooks/use-sort-by-string.js
@@ -26,10 +26,10 @@ export function useSortByString(list, selector) {
     if (sortOrder === "none") return list;
 
     const copyList = [...list];
-    copyList.sort((a, b) => (a.name ?? "").localeCompare(b.name ?? "", "en"));
+    copyList.sort((a, b) => (a.selector ?? "").localeCompare(b.selector ?? "", "en"));
     if (sortOrder === "desc") copyList.reverse();
     return copyList;
-  }, [list, sortOrder]);
+  }, [list, selector, sortOrder]);
 
   return { searchParams, setSearchParams, sortedList, handleSortChange };
 }

--- a/src/client/views/app.jsx
+++ b/src/client/views/app.jsx
@@ -2,23 +2,22 @@ import { Routes, Route, Link } from "react-router-dom";
 import { TopBar } from "@oliasoft-open-source/react-ui-library";
 import Logo from "client/views/images/logo.svg";
 import { Main } from "client/views/main/main";
-import { SitePage } from "./site-page/site";
 import { RigsPage } from "./oil-rigs/oil-rigs";
 import { ChartPage } from "./chart/chart";
+import { SitePage } from "./site-page/site";
 import { useEffect } from "react";
 import { useDispatch } from "react-redux";
-import api from '../store/middleware/api/api'
+import api from "../store/middleware/api/api";
 import { sitesLoaded } from "../store/entities/sites/sites";
 import { oilRigsLoaded } from "../store/entities/oil-rigs/oil-rigs";
 
 export const App = () => {
-const dispatch = useDispatch()
+  const dispatch = useDispatch();
 
   useEffect(() => {
-  dispatch(sitesLoaded())
-  dispatch(oilRigsLoaded())  
-    
-  }, [])
+    dispatch(sitesLoaded());
+    dispatch(oilRigsLoaded());
+  }, []);
 
   return (
     <>

--- a/src/client/views/app.jsx
+++ b/src/client/views/app.jsx
@@ -5,8 +5,21 @@ import { Main } from "client/views/main/main";
 import { SitePage } from "./site-page/site";
 import { RigsPage } from "./oil-rigs/oil-rigs";
 import { ChartPage } from "./chart/chart";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+import api from '../store/middleware/api/api'
+import { sitesLoaded } from "../store/entities/sites/sites";
+import { oilRigsLoaded } from "../store/entities/oil-rigs/oil-rigs";
 
 export const App = () => {
+const dispatch = useDispatch()
+
+  useEffect(() => {
+  dispatch(sitesLoaded())
+  dispatch(oilRigsLoaded())  
+    
+  }, [])
+
   return (
     <>
       <TopBar

--- a/src/client/views/site-page/site.jsx
+++ b/src/client/views/site-page/site.jsx
@@ -1,5 +1,5 @@
 import { Page } from "@oliasoft-open-source/react-ui-library";
-import SiteDetails from "src/client/components/site-details/site-details";
+import { SiteDetails } from "src/client/components/site-details/site-details";
 
 export const SitePage = ({}) => {
   return (


### PR DESCRIPTION
This PR improves data loading 

- dispatches sites and oilRigs at the top level in App.js
- removes the usage of a load button on all views (pages)
- matches oil rigs id's and displays the oil rig names on the oil site view